### PR TITLE
Correção dos pinos dos LEDs e implementação do LED verde

### DIFF
--- a/ATV01MiccrocontroladoresGPIO.c
+++ b/ATV01MiccrocontroladoresGPIO.c
@@ -4,8 +4,8 @@
 
 #define ROWS 4
 #define COLS 4
-uint8_t row_pins[ROWS] = {16, 17, 28, 18};  
-uint8_t col_pins[COLS] = {19, 20, 4, 9};  
+uint8_t row_pins[ROWS] = {2, 3, 4, 5};  
+uint8_t col_pins[COLS] = {6, 7, 8, 9};  
 
 #define LED_RED 13
 #define LED_GREEN 11

--- a/ATV01MiccrocontroladoresGPIO.c
+++ b/ATV01MiccrocontroladoresGPIO.c
@@ -63,11 +63,11 @@ char scan_keypad() {
 void handle_key_press(char key) {
     switch (key) {
         case '1':
-             // Acende o LED vermelho
-            
+            gpio_put(LED_GREEN, 1); // Acende o LED verde
+            break;
         case '2':
-             // Apaga o LED vermelho
-            
+            gpio_put(LED_GREEN, 0);// Apaga o LED verde
+            break;
         case '3':
              gpio_put(LED_BLUE, 1); // acendendo LED Azul
              break;            
@@ -75,11 +75,11 @@ void handle_key_press(char key) {
              gpio_put(LED_BLUE, 0); // acendendo LED Azul
              break;         
         case '5':
-             // Acende o LED verde
-            
+            // Acende o LED vermelha
+
         case '6':
-             // Apaga o LED verde
-            
+             // Apaga o LED vermelha
+            break;
         case '7':
              // Liga o buzzer
             
@@ -95,14 +95,13 @@ void handle_key_press(char key) {
             break;
           
         case 'A':
-            // Acende o LED vermelho enquanto pressionado
-            
+            gpio_put(LED_GREEN, 1); // Acende o LED verde enquanto pressionado
+            break;
         case 'B':
-             // Acende o LED verde enquanto pressionado
-            
+            gpio_put(LED_BLUE, 1); // acendendo LED Azul
+            break;
         case 'C':
-             gpio_put(LED_BLUE, 1); // acendendo LED Azul
-             break;
+            // Acende o LED vermelho enquanto pressionado
         case 'D':
             gpio_put(LED_RED, 1);
             gpio_put(LED_GREEN, 1);
@@ -117,14 +116,13 @@ void handle_key_press(char key) {
 void handle_key_release(char key) {
     switch (key) {
         case 'A':
-             // Apaga o LED vermelho ao soltar
-            
+            gpio_put(LED_GREEN, 0);// Apaga o LED verde ao soltar
+            break;
         case 'B':
-             // Apaga o LED verde ao soltar
-            
-        case 'C':
             gpio_put(LED_BLUE, 0); // acendendo LED Azul
-            break;            
+            break;
+        case 'C':
+            // Apaga o LED vermelho ao soltar            
         case 'D':
             gpio_put(LED_RED, 0);
             gpio_put(LED_GREEN, 0);

--- a/ATV01MiccrocontroladoresGPIO.c
+++ b/ATV01MiccrocontroladoresGPIO.c
@@ -7,9 +7,9 @@
 uint8_t row_pins[ROWS] = {2, 3, 4, 5};  
 uint8_t col_pins[COLS] = {6, 7, 8, 9};  
 
-#define LED_RED 11
-#define LED_GREEN 12
-#define LED_BLUE 13
+#define LED_RED 13
+#define LED_GREEN 11
+#define LED_BLUE 12
 #define BUZZER_PIN 21
 
 const char keys[ROWS][COLS] = {

--- a/diagram.json
+++ b/diagram.json
@@ -1,89 +1,88 @@
 {
-  "version": 1,
-  "author": "Subgrupo02",
-  "editor": "wokwi",
-  "parts": [
-    {
-      "type": "board-pi-pico-w",
-      "id": "pico",
-      "top": 284.75,
-      "left": 281.95,
-      "attrs": { "builder": "pico-sdk" }
-    },
-    {
-      "type": "wokwi-led",
-      "id": "led1",
-      "top": 159.6,
-      "left": 109.4,
-      "attrs": { "color": "blue" }
-    },
-    {
-      "type": "wokwi-led",
-      "id": "led2",
-      "top": 111.6,
-      "left": 109.4,
-      "attrs": { "color": "green" }
-    },
-    {
-      "type": "wokwi-led",
-      "id": "led3",
-      "top": 217.2,
-      "left": 109.4,
-      "attrs": { "color": "red" }
-    },
-    {
-      "type": "wokwi-resistor",
-      "id": "r1",
-      "top": 138.35,
-      "left": 38.4,
-      "attrs": { "value": "1000" }
-    },
-    {
-      "type": "wokwi-resistor",
-      "id": "r2",
-      "top": 195.95,
-      "left": 38.4,
-      "attrs": { "value": "1000" }
-    },
-    {
-      "type": "wokwi-resistor",
-      "id": "r3",
-      "top": 234.35,
-      "left": 38.4,
-      "attrs": { "value": "1000" }
-    },
-    {
-      "type": "wokwi-buzzer",
-      "id": "bz1",
-      "top": 136.8,
-      "left": 232.2,
-      "attrs": { "volume": "0.1" }
-    },
-    { "type": "wokwi-membrane-keypad", "id": "keypad1", "top": 497.2, "left": 140, "attrs": {} }
-  ],
-  "connections": [
-    [ "pico:GP0", "$serialMonitor:RX", "", [] ],
-    [ "pico:GP1", "$serialMonitor:TX", "", [] ],
-    [ "led1:C", "r2:2", "black", [ "v0" ] ],
-    [ "r1:1", "r2:1", "orange", [ "v0" ] ],
-    [ "r2:1", "r3:1", "orange", [ "v0" ] ],
-    [ "r3:1", "pico:GND.4", "orange", [ "v38.4", "h153.6", "v-105.6" ] ],
-    [ "led3:A", "pico:GP13", "red", [ "v0", "h48", "v-86.4" ] ],
-    [ "pico:GP21", "bz1:2", "red", [ "h38.71", "v-201.6" ] ],
-    [ "pico:GND.6", "bz1:1", "black", [ "h48.31", "v-182.4", "h-144" ] ],
-    [ "pico:GP12", "led1:A", "blue", [ "h-115.2", "v-239.96" ] ],
-    [ "led3:C", "r3:2", "black", [ "v0", "h-28.4" ] ],
-    [ "led2:C", "r1:2", "black", [ "v0", "h-28.4" ] ],
-    [ "keypad1:R4", "pico:GP5", "gold", [ "v76.8", "h-230.6", "v-547.2", "h0", "v-9.6" ] ],
-    [ "led2:A", "pico:GP11", "green", [ "v0" ] ],
-    [ "keypad1:R1", "pico:GP16", "yellow", [ "v-48", "h192", "v-307.24" ] ],
-    [ "keypad1:R2", "pico:GP17", "yellow", [ "v-28.8", "h172.4", "v-432.04" ] ],
-    [ "keypad1:R3", "pico:GP28", "yellow", [ "h191.7", "v-480" ] ],
-    [ "keypad1:R4", "pico:GP18", "yellow", [ "h211", "v-307.2", "h0.4", "v-172.84" ] ],
-    [ "keypad1:C1", "pico:GP19", "black", [ "h239.9", "v-76.8", "h0.2", "v-230.44" ] ],
-    [ "keypad1:C2", "pico:GP20", "black", [ "h278.4", "v-403.2" ] ],
-    [ "keypad1:C3", "pico:GP4", "black", [ "h249.45", "v-489.6" ] ],
-    [ "keypad1:C4", "pico:GP9", "black", [ "h326.1", "v-432" ] ]
-  ],
-  "dependencies": {}
-}
+    "version": 1,
+    "author": "Subgrupo02",
+    "editor": "wokwi",
+    "parts": [
+      {
+        "type": "board-pi-pico-w",
+        "id": "pico",
+        "top": 284.75,
+        "left": 281.95,
+        "attrs": { "builder": "pico-sdk" }
+      },
+      {
+        "type": "wokwi-led",
+        "id": "led1",
+        "top": 159.6,
+        "left": 109.4,
+        "attrs": { "color": "blue" }
+      },
+      {
+        "type": "wokwi-led",
+        "id": "led2",
+        "top": 111.6,
+        "left": 109.4,
+        "attrs": { "color": "green" }
+      },
+      {
+        "type": "wokwi-led",
+        "id": "led3",
+        "top": 217.2,
+        "left": 109.4,
+        "attrs": { "color": "red" }
+      },
+      {
+        "type": "wokwi-resistor",
+        "id": "r1",
+        "top": 138.35,
+        "left": 38.4,
+        "attrs": { "value": "1000" }
+      },
+      {
+        "type": "wokwi-resistor",
+        "id": "r2",
+        "top": 195.95,
+        "left": 38.4,
+        "attrs": { "value": "1000" }
+      },
+      {
+        "type": "wokwi-resistor",
+        "id": "r3",
+        "top": 234.35,
+        "left": 38.4,
+        "attrs": { "value": "1000" }
+      },
+      {
+        "type": "wokwi-buzzer",
+        "id": "bz1",
+        "top": 136.8,
+        "left": 232.2,
+        "attrs": { "volume": "0.1" }
+      },
+      { "type": "wokwi-membrane-keypad", "id": "keypad1", "top": 497.2, "left": 188, "attrs": {} }
+    ],
+    "connections": [
+      [ "pico:GP0", "$serialMonitor:RX", "", [] ],
+      [ "pico:GP1", "$serialMonitor:TX", "", [] ],
+      [ "led1:C", "r2:2", "black", [ "v0" ] ],
+      [ "r1:1", "r2:1", "orange", [ "v0" ] ],
+      [ "r2:1", "r3:1", "orange", [ "v0" ] ],
+      [ "r3:1", "pico:GND.4", "orange", [ "v38.4", "h153.6", "v-105.6" ] ],
+      [ "led3:A", "pico:GP13", "red", [ "v0", "h48", "v-86.4" ] ],
+      [ "pico:GP21", "bz1:2", "red", [ "h38.71", "v-201.6" ] ],
+      [ "pico:GND.6", "bz1:1", "black", [ "h48.31", "v-182.4", "h-144" ] ],
+      [ "pico:GP11", "led2:A", "green", [ "h-86.4", "v-278.4" ] ],
+      [ "pico:GP12", "led1:A", "blue", [ "h-115.2", "v-239.96" ] ],
+      [ "led3:C", "r3:2", "black", [ "v0", "h-28.4" ] ],
+      [ "led2:C", "r1:2", "black", [ "v0", "h-28.4" ] ],
+      [ "pico:GP2", "keypad1:R1", "gold", [ "h-134.4", "v537.6", "h134.4" ] ],
+      [ "keypad1:C2", "pico:GP7", "black", [ "v38.4", "h-192", "v9.6" ] ],
+      [ "keypad1:R2", "pico:GP3", "gold", [ "v48", "h-173.2", "v-547.2", "h9.6" ] ],
+      [ "keypad1:R3", "pico:GP4", "gold", [ "v57.6", "h-201.9", "v-547.2", "h9.6" ] ],
+      [ "keypad1:C1", "pico:GP6", "black", [ "v67.2", "h-230.5", "v-470.4", "h0", "v-57.6" ] ],
+      [ "keypad1:R4", "pico:GP5", "gold", [ "v76.8", "h-230.6", "v-547.2", "h0", "v-9.6" ] ],
+      [ "keypad1:C3", "pico:GP8", "black", [ "v86.4", "h-268.95", "v-537.6" ] ],
+      [ "keypad1:C4", "pico:GP9", "black", [ "v96", "h-297.9", "v-566.4" ] ]
+    ],
+    "dependencies": {}
+  }


### PR DESCRIPTION
### O que foi alterado:
- **Correção dos pinos dos LEDs**: Atualizados os pinos para corresponder corretamente aos comentarios e às cores dos LEDs no hardware. Isso resolve a diferença entre a numeração dos pinos e as cores dos LEDs.
- **Implementação do LED verde**: Adicionado o controle do LED verde, permitindo que ele acenda ou apague ao pressionar as teclas do keypad correspondentes.
- **Ajustes no código de controle dos LEDs**: Reorganizados os comandos no `switch` para garantir que correspondam às funções desejadas para cada tecla pressionada no keypad.
